### PR TITLE
Enable Type-Safe Project Accessors for Project References

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,8 @@
 
 rootProject.name = "Xenoglot"
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 pluginManagement {
   repositories {
     google {

--- a/xenoglot-atlas-extended/build.gradle.kts
+++ b/xenoglot-atlas-extended/build.gradle.kts
@@ -87,8 +87,8 @@ kotlin {
         implementation(libs.jetbrains.kotlinx.serialization.core)
         implementation(libs.jetbrains.kotlinx.serialization.json)
 
-        api(project(":xenoglot-atlas"))
-        api(project(":xenoglot-core"))
+        api(projects.xenoglotAtlas)
+        api(projects.xenoglotCore)
       }
     }
     val commonTest by getting {

--- a/xenoglot-atlas/build.gradle.kts
+++ b/xenoglot-atlas/build.gradle.kts
@@ -87,7 +87,7 @@ kotlin {
         implementation(libs.jetbrains.kotlinx.serialization.core)
         implementation(libs.jetbrains.kotlinx.serialization.json)
 
-        api(project(":xenoglot-core"))
+        api(projects.xenoglotCore)
       }
     }
     val commonTest by getting {

--- a/xenoglot-locale/build.gradle.kts
+++ b/xenoglot-locale/build.gradle.kts
@@ -87,9 +87,9 @@ kotlin {
         implementation(libs.jetbrains.kotlinx.serialization.core)
         implementation(libs.jetbrains.kotlinx.serialization.json)
 
-        api(project(":xenoglot-atlas"))
-        api(project(":xenoglot-atlas-extended"))
-        api(project(":xenoglot-core"))
+        api(projects.xenoglotAtlas)
+        api(projects.xenoglotAtlasExtended)
+        api(projects.xenoglotCore)
       }
     }
     val commonTest by getting {


### PR DESCRIPTION
### Summary

This pull request introduces the `enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")` to the `settings.gradle.kts` file. Enabling this feature allows the use of type-safe project accessors, such as `include(projects.xenoglotCore)`, improving the clarity and safety of project references.
